### PR TITLE
Proposed update to CLI

### DIFF
--- a/liftoff/align_features.py
+++ b/liftoff/align_features.py
@@ -11,7 +11,7 @@ from os import path
 
 def align_features_to_target(ref_chroms, target_chroms, args, feature_hierarchy, liftover_type, unmapped_features):
     print("aligning features")
-    target_fasta_dict = split_target_sequence(target_chroms, args.t, args.dir)
+    target_fasta_dict = split_target_sequence(target_chroms, args.target, args.dir)
     genome_size = get_genome_size(target_fasta_dict)
     threads_per_alignment = max(1, math.floor(int(args.p) / len(ref_chroms)))
     sam_files = []
@@ -65,7 +65,7 @@ def align_single_chroms(ref_chroms, target_chroms, threads, args, genome_size, l
 
 
 def get_features_file(ref_chroms, args, liftover_type, index):
-    if ref_chroms[index] == args.r and (liftover_type == "chrm_by_chrm" or liftover_type == "copies"):
+    if ref_chroms[index] == args.reference and (liftover_type == "chrm_by_chrm" or liftover_type == "copies"):
         features_name = 'reference_all'
     elif liftover_type == "unmapped":
         features_name = "unmapped_to_expected_chrom"
@@ -77,8 +77,8 @@ def get_features_file(ref_chroms, args, liftover_type, index):
 
 
 def get_target_file_and_output_file(liftover_type, target_chroms, index, features_name, args):
-    if liftover_type != "chrm_by_chrm" or target_chroms[0] == args.t:
-        target_file = args.t
+    if liftover_type != "chrm_by_chrm" or target_chroms[0] == args.target:
+        target_file = args.target
         out_file_target = "target_all"
     else:
         target_file = args.dir + "/" + target_chroms[index] + ".fa"
@@ -96,7 +96,7 @@ def get_minimap_path(args):
 
 
 def get_target_prefix_name(target_chroms, index, args, liftover_type):
-    if liftover_type != "chrm_by_chrm" or target_chroms[0] == args.t:
+    if liftover_type != "chrm_by_chrm" or target_chroms[0] == args.target:
         prefix = "target_all"
     else:
         prefix = target_chroms[index]

--- a/liftoff/extract_features.py
+++ b/liftoff/extract_features.py
@@ -115,13 +115,13 @@ def add_intermediates(intermediate_types, intermediate_dict, feature_db):
 
 
 def get_gene_sequences(parent_dict, ref_chroms, args, liftover_type):
-    fai = Fasta(args.r)
+    fai = Fasta(args.reference)
     if liftover_type == "unplaced":
         open(args.dir + "/unplaced_genes.fa", 'w')
     for chrom in ref_chroms:
-        fasta_out = get_fasta_out(chrom, args.r, liftover_type, args.dir)
+        fasta_out = get_fasta_out(chrom, args.reference, liftover_type, args.dir)
         sorted_parents = sorted(list(parent_dict.values()), key=lambda x: x.seqid)
-        write_gene_sequences_to_file(chrom, args.r, fai, sorted_parents, fasta_out)
+        write_gene_sequences_to_file(chrom, args.reference, fai, sorted_parents, fasta_out)
         fasta_out.close()
 
 

--- a/liftoff/liftover_types.py
+++ b/liftoff/liftover_types.py
@@ -3,7 +3,7 @@ from liftoff import fix_overlapping_features, lift_features, liftoff_utils, alig
 
 def lift_original_annotation(ref_chroms, target_chroms, lifted_features_list, args, unmapped_features, parents_to_lift):
     liftover_type = "chrm_by_chrm"
-    if target_chroms[0] == args.t and args.exclude_partial == False:
+    if target_chroms[0] == args.target and args.exclude_partial == False:
         min_cov, min_seqid = 0.0, 0.0
     else:
         min_cov, min_seqid = args.a, args.s

--- a/liftoff/run_liftoff.py
+++ b/liftoff/run_liftoff.py
@@ -144,10 +144,10 @@ def get_parent_features_to_lift(feature_types_file):
 
 def map_unmapped_features(unmapped_features, target_chroms, lifted_feature_list, feature_db, feature_hierarchy,
                           ref_parent_order, args):
-    if len(unmapped_features) > 0 and target_chroms[0] != args.t:
+    if len(unmapped_features) > 0 and target_chroms[0] != args.target:
         print("mapping unaligned features to whole genome")
-        ref_chroms = [args.r]
-        target_chroms = [args.t]
+        ref_chroms = [args.reference]
+        target_chroms = [args.target]
         return liftover_types.map_unmapped_genes_agaisnt_all(unmapped_features, ref_chroms, target_chroms,
                                                              lifted_feature_list, feature_db, feature_hierarchy,
                                                              ref_parent_order, args)
@@ -159,7 +159,7 @@ def map_features_from_unplaced_seq(unmapped_features, lifted_feature_list, featu
     if args.unplaced is not None and args.chroms is not None:
         print("mapping unplaced genes")
         ref_chroms, target_chroms = parse_chrm_files(args.unplaced)
-        target_chroms = [args.t]
+        target_chroms = [args.target]
         liftover_types.map_unplaced_genes(unmapped_features, ref_chroms, target_chroms,
                                           lifted_feature_list, feature_db, feature_hierarchy, ref_parent_order, args)
 
@@ -174,8 +174,8 @@ def write_unmapped_features_file(out_arg, unmapped_features):
 def map_extra_copies(args, lifted_feature_list, feature_hierarchy, feature_db, ref_parent_order):
     if args.copies:
         print("mapping gene copies")
-        ref_chroms = [args.r]
-        target_chroms = [args.t]
+        ref_chroms = [args.reference]
+        target_chroms = [args.target]
         liftover_types.map_extra_copies(ref_chroms, target_chroms, lifted_feature_list, feature_hierarchy, feature_db,
                                         ref_parent_order, args)
 

--- a/liftoff/run_liftoff.py
+++ b/liftoff/run_liftoff.py
@@ -7,8 +7,8 @@ def main():
     if args.chroms is not None:
         ref_chroms, target_chroms = parse_chrm_files(args.chroms)
     else:
-        ref_chroms = [args.r]
-        target_chroms = [args.t]
+        ref_chroms = [args.reference]
+        target_chroms = [args.target]
     parent_features_to_lift = get_parent_features_to_lift(args.f)
     lifted_feature_list = {}
     unmapped_features = []
@@ -27,56 +27,92 @@ def main():
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Lift features from one genome assembly to another')
-    group = parser.add_mutually_exclusive_group(required=True)
-    parser.add_argument("-V", "--version", help="show program version", action='version', version="v1.3.0")
-    parser.add_argument('-t', required=True, help="target fasta genome to lift genes to", metavar="<target.fasta>")
-    parser.add_argument('-r', required=True, help="reference fasta genome to lift genes from",
-                        metavar="<reference.fasta>")
-    group.add_argument('-g', help="annotation file to lift over in gff or gtf format", metavar="<ref_annotation.gff>")
-    parser.add_argument('-chroms', required=False,
-                        help="comma seperated file with corresponding chromosomes in the reference,target sequences",
-                        metavar="<chroms.txt>")
-    parser.add_argument('-p', required=False, help="processes", default=1, metavar=1, type=int)
-    parser.add_argument('-o', required=False, help="output file", default='stdout', metavar="<output.gff>")
-    group.add_argument('-db',
-                       help="name of feature database. If none, -g argument must be provided and a database will be "
-                            "built automatically")
-    parser.add_argument('-infer_transcripts', action='store_true', required=False,
-                        help="use if GTF file only includes exon/CDS features and does not include transcripts/mRNA")
-    parser.add_argument('-u', required=False, help="name of file to write unmapped features to",
-                        default="unmapped_features.txt", metavar="<unmapped_features.txt>")
-    parser.add_argument('-infer_genes', action='store_true', required=False,
-                        help="use if GTF file only includes transcripts, exon/CDS features")
-    parser.add_argument('-a', required=False, help="minimum alignment coverage to consider a feature mapped [0-1]",
-                        default=0.5, metavar=0.5, type=float)
-    parser.add_argument('-s', required=False,
-                        help="minimum sequence identity in child features (usually exons/CDS) to consider a feature "
-                             "mapped [0-1]",
-                        default=0.5, metavar=0.5, type=float)
-    parser.add_argument('-unplaced', required=False,
-                        help="text file with name(s) of unplaced sequences to map genes from after genes from "
-                             "chromosomes in chroms.txt are mapped",
-                        metavar="<unplaced_seq_names.txt>")
-    parser.add_argument('-copies', required=False, action='store_true',
-                        help="look for extra gene copies in the target genome")
-    parser.add_argument('-sc', required=False,
-                        help='with -copies, minimum sequence identity in exons/CDS for which a gene is considered a '
-                             'copy. Must be greater than -s',
-                        default=1.0, metavar=1.0, type=float)
-    parser.add_argument('-m', required=False, help="Minimap2 path", metavar='PATH')
-    parser.add_argument('-dir', required=False, help="name of directory to save intermediate fasta and SAM files",
-                        default="intermediate_files", metavar="<intermediate_files_dir>")
-    parser.add_argument('-n', required=False, default=50, metavar=50,
-                        help="max number of Minimap2 alignments to consider for each feature", type=int)
-    parser.add_argument('-f', required=False, metavar="feature types", help="list of feature types to lift-over")
-    parser.add_argument('-d', required=False, metavar=2, default=2, help="distance scaling factor. Alignment nodes " \
-                                                                       "father apart "
-                                                              "than this in the target genome will not be connected in "
-                                                              "the graph", type=float)
-    parser.add_argument('-exclude_partial', default=False, action='store_true',
-                        help="write partial mappings below -s and -a threshold to unmapped_features.txt. If true "
-                             "partial/low sequence identity mappings will be included in the gff file with "
-                             "partial_mapaping=True, low_identity=True in comments")
+
+    parser.add_argument('target', help='target fasta genome to lift genes to')
+    parser.add_argument('reference', help='reference fasta genome to lift genes from')
+
+    refrgrp = parser.add_argument_group('Required input (annotation)')
+    mxgrp = refrgrp.add_mutually_exclusive_group(required=True)
+    mxgrp.add_argument(
+        '-g', metavar='GFF', help='annotation file to lift over in GFF or GTF format'
+    )
+    mxgrp.add_argument(
+        '-db', metavar='DB', help='name of feature database; if not specified, the -g '
+        'argument must be provided and a database will be built automatically'
+    )
+
+    outgrp = parser.add_argument_group('Output')
+    outgrp.add_argument(
+        '-o', default='stdout', metavar='FILE',
+        help='write output to FILE in GFF3 format; by default, output is written to terminal (stdout)'
+    )
+    outgrp.add_argument(
+        '-u', default='unmapped_features.txt', metavar='FILE',
+        help='write unmapped features to FILE; default is "unmapped_features.txt"',
+    )
+    outgrp.add_argument(
+        '-exclude_partial', action='store_true',
+        help='write partial mappings below -s and -a threshold to unmapped_features.txt; if true '
+        'partial/low sequence identity mappings will be included in the gff file with '
+        'partial_mapping=True, low_identity=True in comments'
+    )
+    outgrp.add_argument(
+        '-dir', default='intermediate_files', metavar='DIR',
+        help='name of directory to save intermediate fasta and SAM files; default is "intermediate_files"',
+    )
+
+    aligngrp = parser.add_argument_group('Alignment filtering')
+    aligngrp.add_argument(
+        '-a', default=0.5, metavar='A', type=float,
+        help='designate a feature mapped only if it aligns with coverage ≥A; by default A=0.5',
+    )
+    aligngrp.add_argument(
+        '-s', default=0.5, metavar='S', type=float,
+        help='designate a feature mapped only if its child features (usually exons/CDS) align '
+        'with sequence identity ≥S; by default S=0.5'
+    )
+    aligngrp.add_argument(
+        '-n', default=50, metavar='N', type=int,
+        help='consider at most N Minimap2 alignments for each feature; by default N=50'
+    )
+    aligngrp.add_argument(
+        '-d', metavar='D', default=2.0, type=float,
+        help='distance scaling factor; alignment nodes separated by more than a factor of D in '
+        'the target genome will not be connected in the graph; by default D=2.0'
+    )
+
+    parser.add_argument('-V', '--version', help='show program version', action='version', version='v1.3.0')
+    parser.add_argument(
+        '-p', default=1, type=int, metavar='P', help='use P parallel processes to accelerate alignment; by default P=1'
+    )
+    parser.add_argument('-m', help='Minimap2 path', metavar='PATH')
+    parser.add_argument('-f', metavar='TYPES', help='list of feature types to lift over')
+    parser.add_argument(
+        '-infer_genes', action='store_true',
+        help='use if annotation file only includes transcripts, exon/CDS features'
+    )
+    parser.add_argument(
+        '-infer_transcripts', action='store_true', required=False,
+        help='use if annotation file only includes exon/CDS features and does not include transcripts/mRNA'
+    )
+    parser.add_argument(
+        '-chroms', metavar='TXT', help='comma seperated file with corresponding chromosomes in '
+        'the reference,target sequences',
+    )
+    parser.add_argument(
+        '-unplaced', metavar='TXT',
+        help='text file with name(s) of unplaced sequences to map genes from after genes from '
+        'chromosomes in chroms.txt are mapped; default is "unplaced_seq_names.txt"',
+    )
+    parser.add_argument('-copies', action='store_true', help='look for extra gene copies in the target genome')
+    parser.add_argument(
+        '-sc', default=1.0, metavar='SC', type=float,
+        help='with -copies, minimum sequence identity in exons/CDS for which a gene is considered '
+        'a copy; must be greater than -s; default is 1.0',
+    )
+    parser._positionals.title = 'Required input (sequences)'
+    parser._optionals.title = 'Miscellaneous settings'
+    parser._action_groups = [parser._positionals, refrgrp, outgrp, aligngrp, parser._optionals]
     args = parser.parse_args()
     if (float(args.s) > float(args.sc)):
         parser.error("-sc must be greater than or equal to -s")


### PR DESCRIPTION
Greetings! First, I want to say thank you for publishing this software. It is very well done and will be a valuable contribution to the community.

I wanted to propose a few changes to Liftoff's command-line interface: nothing too extensive, but a handful of changes to the usage statement that could improve usability for new users.

1. **Organize the arguments into argument groups with concise descriptions**: With over a dozen settings and parameters, adding a little bit of structure here could help users visually parse through everything and find what they need.
2. **More clearly distinguish required arguments vs optional arguments** with argument group descriptions and by making the target and reference Fasta files positional arguments. (It is a common UNIX convention to use positional arguments for required inputs that have no reasonable default, although it's routinely violated by bioinformatics tools.)
3. **Reformat metavariables** to clarify the description for some arguments.

The proposed update would produce a usage statement that looks like this.

```
[standage@desky ~] $ liftoff -h
usage: liftoff [-h] (-g GFF | -db DB) [-o FILE] [-u FILE] [-exclude_partial]
               [-dir DIR] [-a A] [-s S] [-n N] [-d D] [-V] [-p P] [-m PATH]
               [-f TYPES] [-infer_genes] [-infer_transcripts] [-chroms TXT]
               [-unplaced TXT] [-copies] [-sc SC]
               target reference

Lift features from one genome assembly to another

Required input (sequences):
  target              target fasta genome to lift genes to
  reference           reference fasta genome to lift genes from

Required input (annotation):
  -g GFF              annotation file to lift over in GFF or GTF format
  -db DB              name of feature database; if not specified, the -g
                      argument must be provided and a database will be built
                      automatically

Output:
  -o FILE             write output to FILE in GFF3 format; by default, output
                      is written to terminal (stdout)
  -u FILE             write unmapped features to FILE; default is
                      "unmapped_features.txt"
  -exclude_partial    write partial mappings below -s and -a threshold to
                      unmapped_features.txt; if true partial/low sequence
                      identity mappings will be included in the gff file with
                      partial_mapping=True, low_identity=True in comments
  -dir DIR            name of directory to save intermediate fasta and SAM
                      files; default is "intermediate_files"

Alignment filtering:
  -a A                designate a feature mapped only if it aligns with
                      coverage ≥A; by default A=0.5
  -s S                designate a feature mapped only if its child features
                      (usually exons/CDS) align with sequence identity ≥S; by
                      default S=0.5
  -n N                consider at most N Minimap2 alignments for each feature;
                      by default N=50
  -d D                distance scaling factor; alignment nodes separated by
                      more than a factor of D in the target genome will not be
                      connected in the graph; by default D=2.0

Miscellaneous settings:
  -h, --help          show this help message and exit
  -V, --version       show program version
  -p P                use P parallel processes to accelerate alignment; by
                      default P=1
  -m PATH             Minimap2 path
  -f TYPES            list of feature types to lift over
  -infer_genes        use if annotation file only includes transcripts,
                      exon/CDS features
  -infer_transcripts  use if annotation file only includes exon/CDS features
                      and does not include transcripts/mRNA
  -chroms TXT         comma seperated file with corresponding chromosomes in
                      the reference,target sequences
  -unplaced TXT       text file with name(s) of unplaced sequences to map
                      genes from after genes from chromosomes in chroms.txt
                      are mapped; default is "unplaced_seq_names.txt"
  -copies             look for extra gene copies in the target genome
  -sc SC              with -copies, minimum sequence identity in exons/CDS for
                      which a gene is considered a copy; must be greater than
                      -s; default is 1.0
```

The names of the optional arguments were left untouched, but `args.t` and `args.r` were replaced with `args.target` and `args.reference` throughout the codebase.