### PR TITLE
Make the "parent" GFF field configurable

### DIFF
--- a/liftoff/extract_features.py
+++ b/liftoff/extract_features.py
@@ -30,17 +30,22 @@ def create_feature_db_connections(args):
         disable_genes = False
     else:
         disable_genes = True
-    feature_db = build_database(args.db, args.g, disable_transcripts, disable_genes)
+    feature_db = build_database(args.db, args.g, disable_transcripts, disable_genes, args.parent_field)
     return feature_db
 
 
+def build_database(db, gff_file, disable_transcripts, disable_genes, parent_field):
 
-def build_database(db, gff_file, disable_transcripts, disable_genes,):
+    def transform_parent(f):
+        if parent_field != "Parent" and parent_field in f.attributes:
+            f.attributes["Parent"] = f.attributes[parent_field]
+        return f
+
     if db is None:
         try:
             feature_db = gffutils.create_db(gff_file, gff_file + "_db", merge_strategy="create_unique", force=True,
                                             disable_infer_transcripts=disable_transcripts,
-                                            disable_infer_genes=disable_genes, verbose=True)
+                                            disable_infer_genes=disable_genes, verbose=True, transform=transform_parent)
         except:
             find_problem_line(gff_file)
     else:

--- a/liftoff/run_liftoff.py
+++ b/liftoff/run_liftoff.py
@@ -150,6 +150,10 @@ def parse_args(arglist):
                                                                                         "(partial, missing start, "
                                                                                         "missing stop, inframe stop "
                                                                                         "codon)")
+    parser.add_argument(
+        '-parent_field', metavar='TXT', help='GFF field used to identify the parent '
+                                       'of the feature; by default "Parent"',
+    )
     parser._positionals.title = 'Required input (sequences)'
     parser._optionals.title = 'Miscellaneous settings'
     parser._action_groups = [parser._positionals, refrgrp, outgrp, aligngrp, parser._optionals]


### PR DESCRIPTION
This is usefult for example in the case of miRBase GFF files, where "Derives_from" is used instead of "Parent".

`gffutils.create_db` accepts a `transform` function which can be used to adjust non-compliant GFF files. In this case we use it to create a "Parent" attribute with the content of another attribute, which is specified by the user using the new "-parent_field" argument.

closes #78