### PR TITLE
Check for in-frame stops even if a gene is incomplete

### DIFF
--- a/liftoff/polish.py
+++ b/liftoff/polish.py
@@ -69,15 +69,21 @@ def count_good_cds(cds_features, ref_faidx, target_faidx, ref_children, target_s
             warnings.simplefilter('ignore')
             protein = longest_ORF.translate()
         transcript.attributes["valid_ORF"] = ['False']
+        validORF = True
         if len(protein) < 3:
             transcript.attributes["partial_ORF"] = ['True']
-        elif missing_start(protein):
-                transcript.attributes["missing_start_codon"] = ['True']
-        elif missing_stop(protein):
-            transcript.attributes["missing_stop_codon"] = ['True']
-        elif inframe_stop(protein):
-            transcript.attributes["inframe_stop_codon"] = ['True']
+            validORF = False
         else:
+            if missing_start(protein):
+                transcript.attributes["missing_start_codon"] = ['True']
+                validORF = False
+            if missing_stop(protein):
+                transcript.attributes["missing_stop_codon"] = ['True']
+                validORF = False
+            if inframe_stop(protein):
+                transcript.attributes["inframe_stop_codon"] = ['True']
+                validORF = False
+        if validORF:
             transcript.attributes["valid_ORF"] = ['True']
             good_cds_count +=1
         if longest_ORF != cds_seq:


### PR DESCRIPTION
Currently, the mapped genes are scanned for in-frame stop codons only if they are complete. Similarly, if a gene is 5' incomplete, the 3' end is not checked.

This pull request changes the behavior to check and report the presence of start, stops, and in-frame stops independently.

This is useful because an incomplete mapping which preserves the ORF is much less concerning than an incomplete mapping with in-frame stops. There is no way to distinguish the two in the current output.