### PR TITLE
BUG FIX: minimap2 missing space cmd - run_liftoff.py

### DIFF
--- a/liftoff/run_liftoff.py
+++ b/liftoff/run_liftoff.py
@@ -165,7 +165,7 @@ def parse_args(arglist):
     if '-p' not in args.mm2_options:
         args.mm2_options += " -p 0.5"
     if '--end-bonus' not in args.mm2_options:
-        args.mm2_options += "--end-bonus 5"
+        args.mm2_options += " --end-bonus 5"
     if (float(args.s) > float(args.sc)):
         parser.error("-sc must be greater than or equal to -s")
     if (args.chroms is None and args.unplaced is not None):


### PR DESCRIPTION
fixes: if -mm2_options is provided, then minimap2 runs as `-p 0.5--end-bonus 5`, (a missing space)